### PR TITLE
sonarqube-latest: Bump version to 2026.3.0

### DIFF
--- a/sonarqube-latest/compose.yaml
+++ b/sonarqube-latest/compose.yaml
@@ -21,7 +21,7 @@ services:
     container_name: sonarqube-latest
     depends_on:
       - sonarqube-latest-postgres
-    image: sonarqube:2026.2.1-enterprise
+    image: sonarqube:2026.3.0-enterprise
     environment:
       - SONAR_JDBC_URL=jdbc:postgresql://sonarqube-latest-postgres/sonarqube?currentSchema=public
       - SONAR_JDBC_USERNAME=sonar


### PR DESCRIPTION
----
## Summary by Gitar

- **Version bump:**
  - Update `sonarqube` image tag from `2026.2.1-enterprise` to `2026.3.0-enterprise` in `sonarqube-latest/compose.yaml`.

<sub>This will update automatically on new commits.</sub>